### PR TITLE
Show send-to button on Twitch channels

### DIFF
--- a/webextension/main.js
+++ b/webextension/main.js
@@ -253,7 +253,7 @@ function handleComplete(resp) {
 }
 
 function setupButton(){
-  var gettingAllTabs = browser.tabs.query({url:['*://www.youtube.com/watch*','*://vimeo.com/*','*://twitch.tv/videos/*']});
+  var gettingAllTabs = browser.tabs.query({url:['*://www.youtube.com/watch*','*://vimeo.com/*','*://twitch.tv/*']});
   gettingAllTabs.then((tabs) => {
     for (let tab of tabs) {
       browser.pageAction.show(tab.id);
@@ -267,8 +267,9 @@ function displayButton(tabId, changeInfo, tabInfo) {
     var regExp = /^.*(youtube.com\/watch.*[\?\&]v=)([^#\&\?]*).*/;
     var vimeoRex = /^.*vimeo.com\/([0-9]+)/;
     var twitchVideoRex = /^.*twitch.tv\/videos\/([0-9]+)$/;
+    var twitchLiveRex = /^.*twitch.tv\/([a-zA-Z0-9_]+)$/;
 
-    if (tabInfo.url.match(regExp) || tabInfo.url.match(vimeoRex) || tabInfo.url.match(twitchVideoRex)) {
+    if (tabInfo.url.match(regExp) || tabInfo.url.match(vimeoRex) || tabInfo.url.match(twitchVideoRex) || tabInfo.url.match(twitchLiveRex)) {
       browser.pageAction.show(tabId);
     }
 }

--- a/webextension/main.js
+++ b/webextension/main.js
@@ -269,8 +269,14 @@ function displayButton(tabId, changeInfo, tabInfo) {
     var twitchVideoRex = /^.*twitch.tv\/videos\/([0-9]+)$/;
     var twitchLiveRex = /^.*twitch.tv\/([a-zA-Z0-9_]+)$/;
 
-    if (tabInfo.url.match(regExp) || tabInfo.url.match(vimeoRex) || tabInfo.url.match(twitchVideoRex) || tabInfo.url.match(twitchLiveRex)) {
+    if (tabInfo.url.match(regExp) || tabInfo.url.match(vimeoRex) || tabInfo.url.match(twitchVideoRex)) {
       browser.pageAction.show(tabId);
+    }
+    if (tabInfo.url.match(twitchLiveRex)) {
+      var notTwitchChannel = /twitch.tv\/(friends|inventory|subscriptions|payments)/;
+      if (! (tabInfo.url.match(notTwitchChannel))) {
+        browser.pageAction.show(tabId);
+      }
     }
 }
 


### PR DESCRIPTION
I wanted the URL bar to show the send-to-kodi button on live twitch streams, so I made these modifications. This isn't exactly perfect, it will match friends/subscriptions/inventory/payments pages which won't play, but at least it will show the button on live streams. Depending on feedback, it's possible to add features to blacklist certain words from the channel name.